### PR TITLE
fix build errors on new gcc

### DIFF
--- a/nkc_frontend/helpers/nkc_stb_image.h
+++ b/nkc_frontend/helpers/nkc_stb_image.h
@@ -61,7 +61,7 @@ NK_API struct nk_image nkc_load_image_gl(unsigned char *data, int x, int y, int 
 
 NK_API struct nk_image nkc_load_image_memory(struct nkc* nkcHandle, const void* membuf, int membufSize){
     int x,y,n;    
-    unsigned char *data = stbi_load_from_memory(membuf, membufSize, &x, &y, &n, 0);
+    unsigned char *data = stbi_load_from_memory((const stbi_uc*) membuf, membufSize, &x, &y, &n, 0);
     return nkc_load_image_gl(data, x, y, n);
 }
 

--- a/nkc_frontend/nkc_sdl.h
+++ b/nkc_frontend/nkc_sdl.h
@@ -275,7 +275,7 @@ NK_API int nkc_get_desktop_size(struct nkc* nkcHandle, int* width, int* height){
 }
 
 NK_API char nkc_get_key_char(int code){
-    const char* name = SDL_GetScancodeName(code);
+    const char* name = SDL_GetScancodeName((SDL_Scancode)code);
     if( strlen(name) == 1 ){
         if( (name[0]>='A') && (name[0]<='Z') ){
             return name[0] - 'A' + 'a'; /* 'a' for NKC_KEY_A */


### PR DESCRIPTION
Just two explicit casts necessary.